### PR TITLE
Resurrection manager for dependency properties and metadata

### DIFF
--- a/Src/Noesis/Core/Src/Core/Extend.cs
+++ b/Src/Noesis/Core/Src/Core/Extend.cs
@@ -1,5 +1,3 @@
-#undef NETSTANDARD
-
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;

--- a/Src/Noesis/Core/Src/Proxies/BaseComponentExtend.cs
+++ b/Src/Noesis/Core/Src/Proxies/BaseComponentExtend.cs
@@ -27,6 +27,11 @@ namespace Noesis
             }
         }
 
+        protected internal void ReplacePointer(IntPtr cPtr)
+        {
+            Init(cPtr, false, false);
+        }
+        
         private void Init(IntPtr cPtr, bool cMemoryOwn, bool registerExtend)
         {
             swigCPtr = new HandleRef(this, cPtr);

--- a/Src/Noesis/Core/Src/Proxies/DependencyPropertyMetadataOverrideResurrectionManager.cs
+++ b/Src/Noesis/Core/Src/Proxies/DependencyPropertyMetadataOverrideResurrectionManager.cs
@@ -1,0 +1,77 @@
+﻿namespace Noesis
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using static DependencyPropertyResurrectionManager;
+
+    /// <summary>
+    /// This class is used for resurrection of the default value override (such as for default style override).
+    /// </summary>
+    public class DependencyPropertyMetadataOverrideResurrectionManager
+    {
+        private static readonly Dictionary<WeakTypeEntry, List<StoredPropertyMetadataEntry>> Dictionary
+            = new Dictionary<WeakTypeEntry, List<StoredPropertyMetadataEntry>>();
+
+        public static void Register(
+            DependencyProperty dependencyProperty,
+            Type forType,
+            PropertyMetadata typeMetadata)
+        {
+            var weakTypeEntry = new WeakTypeEntry(forType);
+            if (!Dictionary.TryGetValue(weakTypeEntry, out var listMetadata))
+            {
+                listMetadata = new List<StoredPropertyMetadataEntry>();
+                Dictionary[weakTypeEntry] = listMetadata;
+            }
+
+            listMetadata.Add(new StoredPropertyMetadataEntry(dependencyProperty, typeMetadata));
+        }
+
+        public static void TryResurrect(Type forType)
+        {
+            var weakTypeEntry = new WeakTypeEntry(forType);
+            if (!Dictionary.TryGetValue(weakTypeEntry, out var listMetadata))
+            {
+                return;
+            }
+
+            // remove the reference as new overrides will be created during the following OverrideMetadata calls 
+            Dictionary.Remove(weakTypeEntry);
+
+            foreach (var entry in listMetadata)
+            {
+                var dependencyPropertyName = entry.DependencyPropertyName + "Property";
+                var property = forType.GetProperty(dependencyPropertyName,
+                                                   BindingFlags.FlattenHierarchy
+                                                   | BindingFlags.Static
+                                                   | BindingFlags.Public
+                                                   | BindingFlags.NonPublic);
+                if (property is null)
+                {
+                    Log.Error("Dependency property not found: "
+                              + dependencyPropertyName
+                              + " in "
+                              + forType.FullName);
+                    continue;
+                }
+
+                var dependencyProperty = property.GetValue(null) as DependencyProperty;
+                if (dependencyProperty is null)
+                {
+                    Log.Error("The dependency property doesn't exist");
+                    continue;
+                }
+
+                if (dependencyProperty.IsDisposed)
+                {
+                    Log.Error("The dependency property is disposed");
+                    continue;
+                }
+
+                var metadata = entry.CreateFrameworkPropertyMetadata();
+                dependencyProperty.OverrideMetadata(forType, metadata);
+            }
+        }
+    }
+}

--- a/Src/Noesis/Core/Src/Proxies/DependencyPropertyResurrectionManager.cs
+++ b/Src/Noesis/Core/Src/Proxies/DependencyPropertyResurrectionManager.cs
@@ -1,0 +1,166 @@
+﻿namespace Noesis
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class DependencyPropertyResurrectionManager
+    {
+        private static readonly Dictionary<WeakTypeEntry, List<PropertyData>> Dictionary
+            = new Dictionary<WeakTypeEntry, List<PropertyData>>();
+
+        public static void Register(
+            DependencyProperty dependencyProperty,
+            string name,
+            Type propertyType,
+            Type ownerType,
+            PropertyMetadata propertyMetadata)
+        {
+            var weakTypeEntry = new WeakTypeEntry(ownerType);
+            if (!Dictionary.TryGetValue(weakTypeEntry, out var properties))
+            {
+                properties = new List<PropertyData>();
+                Dictionary[weakTypeEntry] = properties;
+            }
+            else
+            {
+                foreach (var property in properties)
+                {
+                    if (name == property.Name)
+                    {
+                        // already registered
+                        return;
+                    }
+                }
+            }
+
+            properties.Add(
+                new PropertyData(name,
+                                 propertyType,
+                                 propertyMetadata,
+                                 dependencyProperty));
+        }
+
+        public static bool TryResurrect(
+            IntPtr cPtr,
+            string name,
+            Type ownerType,
+            out DependencyProperty dependencyProperty)
+        {
+            var weakTypeEntry = new WeakTypeEntry(ownerType);
+            if (!Dictionary.TryGetValue(weakTypeEntry, out var properties))
+            {
+                dependencyProperty = null;
+                return false;
+            }
+
+            foreach (var property in properties)
+            {
+                if (name != property.Name)
+                {
+                    continue;
+                }
+
+                property.WeakDependencyProperty.TryGetTarget(out dependencyProperty);
+                if (ReferenceEquals(dependencyProperty, null))
+                {
+                    return false;
+                }
+
+                dependencyProperty.ReplacePointer(cPtr);
+            }
+
+            dependencyProperty = null;
+            return false;
+        }
+
+        public static void TryResurrectAll(Type ownerType)
+        {
+            var weakTypeEntry = new WeakTypeEntry(ownerType);
+            if (!Dictionary.TryGetValue(weakTypeEntry, out var properties))
+            {
+                return;
+            }
+
+            foreach (var propertyData in properties)
+            {
+                var weakPropertyTypeEntry = propertyData.WeakPropertyTypeEntry;
+                var propertyType = weakPropertyTypeEntry.Type;
+                if (propertyType is null)
+                {
+                    continue;
+                }
+
+                var propertyMetadata = propertyData.PropertyMetadata.CreateFrameworkPropertyMetadata();
+                DependencyProperty.Register(propertyData.Name,
+                                            propertyType,
+                                            ownerType,
+                                            propertyMetadata);
+            }
+        }
+
+        internal struct WeakTypeEntry : IEquatable<WeakTypeEntry>
+        {
+            private readonly int hashCode;
+
+            private readonly WeakReference<Type> weakReference;
+
+            public WeakTypeEntry(Type type)
+            {
+                this.weakReference = new WeakReference<Type>(type);
+                this.hashCode = type.GetHashCode();
+            }
+
+            public Type Type
+            {
+                get
+                {
+                    return this.weakReference.TryGetTarget(out var type)
+                               ? type
+                               : null;
+                }
+            }
+
+            public bool Equals(WeakTypeEntry other)
+            {
+                return this.hashCode == other.hashCode
+                       && this.weakReference.TryGetTarget(out var typeA)
+                       && other.weakReference.TryGetTarget(out var typeB)
+                       && ReferenceEquals(typeA, typeB);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is WeakTypeEntry other
+                       && this.Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return this.hashCode;
+            }
+        }
+
+        private struct PropertyData
+        {
+            public WeakReference<DependencyProperty> WeakDependencyProperty;
+
+            public PropertyData(
+                string name,
+                Type propertyType,
+                PropertyMetadata propertyMetadata,
+                DependencyProperty dependencyProperty)
+            {
+                this.Name = name;
+                this.WeakPropertyTypeEntry = new WeakTypeEntry(propertyType);
+                this.WeakDependencyProperty = new WeakReference<DependencyProperty>(dependencyProperty);
+                this.PropertyMetadata = new StoredPropertyMetadataEntry(dependencyProperty, propertyMetadata);
+            }
+
+            public string Name { get; }
+
+            public StoredPropertyMetadataEntry PropertyMetadata { get; }
+
+            public WeakTypeEntry WeakPropertyTypeEntry { get; }
+        }
+    }
+}

--- a/Src/Noesis/Core/Src/Proxies/StoredPropertyMetadataEntry.cs
+++ b/Src/Noesis/Core/Src/Proxies/StoredPropertyMetadataEntry.cs
@@ -1,0 +1,31 @@
+﻿namespace Noesis
+{
+    /// <summary>
+    /// Used for resurrection of dependency properties.
+    /// </summary>
+    internal struct StoredPropertyMetadataEntry
+    {
+        public readonly CoerceValueCallback CoerceValueCallback;
+
+        public readonly object DefaultValue;
+
+        public readonly string DependencyPropertyName;
+
+        public readonly PropertyChangedCallback PropertyChangedCallback;
+
+        public StoredPropertyMetadataEntry(DependencyProperty dependencyProperty, PropertyMetadata metadata)
+        {
+            this.DependencyPropertyName = dependencyProperty.Name;
+            this.DefaultValue = metadata.DefaultValue;
+            this.PropertyChangedCallback = metadata.PropertyChangedCallback;
+            this.CoerceValueCallback = metadata.CoerceValueCallback;
+        }
+
+        public PropertyMetadata CreateFrameworkPropertyMetadata()
+        {
+            return new FrameworkPropertyMetadata(this.DefaultValue,
+                                                 this.PropertyChangedCallback,
+                                                 this.CoerceValueCallback);
+        }
+    }
+}


### PR DESCRIPTION
Hello!

Here is the promised (https://www.noesisengine.com/bugs/view.php?id=1897) resurrection manager for dependency properties and metadata (workaround for .NET 5 as static constructors cannot be called more than once there).
So far it works great for the past 2.5 weeks—thousands of players, no issue reports.
Consider refactoring/renaming as you wish. Also, I was not paying max attention to keep the old C# syntax—you may need to edit it a bit to make it work under older C# version.

Regards!