### PR TITLE
Fix getter for DependencyProperties of type Type

### DIFF
--- a/Src/Noesis/Core/Src/Proxies/DependencyObjectExtend.cs
+++ b/Src/Noesis/Core/Src/Proxies/DependencyObjectExtend.cs
@@ -404,7 +404,7 @@ namespace Noesis
                 IntPtr ptr = Noesis_DependencyGet_Type(cPtr, dp);
                 if (ptr != IntPtr.Zero)
                 {
-                    Noesis.Extend.NativeTypeInfo info = Noesis.Extend.GetNativeTypeInfo(cPtr);
+                    Noesis.Extend.NativeTypeInfo info = Noesis.Extend.GetNativeTypeInfo(ptr);
                     return info.Type;
                 }
                 return null;


### PR DESCRIPTION
Fix getter for DependencyProperties of type Type returning type of the DependencyObject that contains the property instead of the property value.