### PR TITLE
displays/x11: fix marshal field

### DIFF
--- a/Src/NoesisApp/Displays/X11/Src/XDisplay.cs
+++ b/Src/NoesisApp/Displays/X11/Src/XDisplay.cs
@@ -664,7 +664,7 @@ namespace NoesisApp
             public EventMask do_not_propagate_mask;
             public bool override_redirect;
             public IntPtr colormap;
-            public Cursor cursor;
+            public IntPtr cursor;
         }
 
         [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
This fix an x11 display crash on ubuntu 22.04 (at least) that is present since v 3.1.2 :  
```
Unhandled exception. System.TypeLoadException: Cannot marshal field 'cursor' of type 'XSetWindowAttributes': Invalid managed/unmanaged type combination (Marshaling to and from COM interface pointers isn't supported).
```
Please note that i'm not sure if it's the right way to fix it, but it seems to works fine here.